### PR TITLE
Fix tests

### DIFF
--- a/xt/20_worepan.t
+++ b/xt/20_worepan.t
@@ -11,7 +11,7 @@ BEGIN {
 }
 
 my $worepan = WorePAN->new(
-  files => ['ISHIGAKI/WorePAN-0.09.tar.gz'],
+  files => ['ISHIGAKI/WorePAN-0.17.tar.gz'],
   no_network => 0,
   cleanup => 1,
   no_indices => 1,

--- a/xt/20_worepan.t
+++ b/xt/20_worepan.t
@@ -30,7 +30,7 @@ all_permissions_ok('ISHIGAKI');
 TEST
 
   my $dir = pushd($basedir);
-  my $output = `prove -l xt/perms.t`;
+  my $output = `prove -l xt/perms.t 2>&1`;
   like $output => qr/Result: PASS/;
   # note $output;
 
@@ -42,7 +42,7 @@ local $ENV{RELEASE_TESTING} = 1;
 all_permissions_ok('LOCAL');
 TEST
 
-  $output = `prove -l xt/perms.t`;
+  $output = `prove -l xt/perms.t 2>&1`;
   like $output => qr/Result: FAIL/;
   # note $output;
 });
@@ -68,7 +68,7 @@ all_permissions_ok('ISHIGAKI', {strict => 1});
 TEST
 
   my $dir = pushd($basedir);
-  my $output = `prove -l xt/perms.t`;
+  my $output = `prove -l xt/perms.t 2>&1`;
   like $output => qr/Result: PASS/;
   # note $output;
 
@@ -84,7 +84,7 @@ TEST
   my $manifest = $basedir->file("MANIFEST");
   $manifest->save($manifest->slurp."\nlib/DBD/SQLite/NOSUCHMODULE.pm\n");
 
-  $output = `prove -l xt/perms.t`;
+  $output = `prove -l xt/perms.t 2>&1`;
   like $output => qr/Result: FAIL/;
   note $output;
 });

--- a/xt/30_authority_mismatch.t
+++ b/xt/30_authority_mismatch.t
@@ -14,7 +14,7 @@ BEGIN {
 }
 
 my $worepan = WorePAN->new(
-  files => ['ISHIGAKI/WorePAN-0.09.tar.gz'],
+  files => ['ISHIGAKI/WorePAN-0.17.tar.gz'],
   no_network => 0,
   cleanup => 1,
   no_indices => 1,


### PR DESCRIPTION
This PR fixes tests.

Before:
```
❯ TEST_POD=1 prove -l xt
xt/10_self.t ................ ok
xt/10_self_with_id.t ........ ok
xt/10_strict_self.t ......... ok
xt/20_worepan.t ............. Can't fetch I/IS/ISHIGAKI/WorePAN-0.09.tar.gz
xt/20_worepan.t ............. 1/?
#   Failed test 'Some of the maintainers of this distribution (ADAMK DUNCAND MSERGEANT) won't have permissions for the following package(s): DBD::SQLite::NOSUCHMODULE.'
#   at /Users/skaji/src/github.com/charsbar/Test-PAUSE-Permissions/lib/Test/PAUSE/Permissions.pm line 88.
# Looks like you failed 1 test of 10.
xt/20_worepan.t ............. ok
xt/30_authority_mismatch.t .. Can't fetch I/IS/ISHIGAKI/WorePAN-0.09.tar.gz
xt/30_authority_mismatch.t .. skipped: (no reason given)
xt/99_pod.t ................. ok
xt/99_podcoverage.t ......... ok

Test Summary Report
-------------------
xt/30_authority_mismatch.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
Files=7, Tests=7, 33 wallclock secs ( 0.04 usr  0.02 sys + 15.26 cusr  1.89 csys = 17.21 CPU)
Result: FAIL
```

After:
```
❯ TEST_POD=1 prove -l xt
xt/10_self.t ................ ok
xt/10_self_with_id.t ........ ok
xt/10_strict_self.t ......... ok
xt/20_worepan.t ............. ok
xt/30_authority_mismatch.t .. ok
xt/99_pod.t ................. ok
xt/99_podcoverage.t ......... ok
All tests successful.
Files=7, Tests=17, 68 wallclock secs ( 0.04 usr  0.02 sys + 31.06 cusr  3.84 csys = 34.96 CPU)
Result: PASS
```